### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libexadrums (0.6.0-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Submit, Repository.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 03 Feb 2022 12:36:47 -0000
+
 libexadrums (0.6.0-1) unstable; urgency=medium
 
   * New upstream version.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 libexadrums (0.6.0-2) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Submit, Repository.
+  * Update standards version to 4.6.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 03 Feb 2022 12:36:47 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends:
  libtinyxml2-dev,
  pkg-config,
  zlib1g-dev,
-Standards-Version: 4.5.1
+Standards-Version: 4.6.0
 Rules-Requires-Root: no
 Homepage: https://exadrums.com
 Vcs-Git: https://github.com/SpintroniK/libeXaDrums.git -b debian

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,3 +1,4 @@
 Bug-Database: https://github.com/SpintroniK/libeXaDrums/issues
-Repository: https://github.com/SpintroniK/libeXaDrums
+Bug-Submit: https://github.com/SpintroniK/libeXaDrums/issues/new
+Repository: https://github.com/SpintroniK/libeXaDrums.git
 Repository-Browse: https://github.com/SpintroniK/libeXaDrums.git


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Bug-Submit, Repository. ([upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))

* Update standards version to 4.6.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/libexadrums/f6185b72-52c5-4b15-b924-e269e26d575e.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/f6185b72-52c5-4b15-b924-e269e26d575e/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/f6185b72-52c5-4b15-b924-e269e26d575e/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/f6185b72-52c5-4b15-b924-e269e26d575e/diffoscope)).
